### PR TITLE
Fix argument error

### DIFF
--- a/Sources/UcglibSwiftIO/UcglibSwiftIO.swift
+++ b/Sources/UcglibSwiftIO/UcglibSwiftIO.swift
@@ -1266,17 +1266,17 @@ func ucg_com_arduino_4wire_HW_SPI(ucg: UnsafeMutablePointer<ucg_t>!, msg: Int16,
     case UCG_COM_MSG_CHANGE_RESET_LINE:
         let rstPin = pin_list[Int(UCG_PIN_RST)]
         
-        rstPin?.write(msg != 0 ? true : false)
+        rstPin?.write(arg != 0 ? true : false)
         break
         
     case UCG_COM_MSG_CHANGE_CS_LINE:
         let csPin = pin_list[Int(UCG_PIN_CS)]
         
-        csPin?.write(msg != 0 ? true : false)
+        csPin?.write(arg != 0 ? true : false)
         break
         
     case UCG_COM_MSG_CHANGE_CD_LINE:
-        pin_list[Int(UCG_PIN_CD)]!.write(msg != 0 ? true : false)
+        pin_list[Int(UCG_PIN_CD)]!.write(arg != 0 ? true : false)
         break
         
     case UCG_COM_MSG_SEND_BYTE:


### PR DESCRIPTION
1. The `arg` in method `ucg_com_arduino_4wire_HW_SPI` is mistakenly written as `msg` so the pins are not correctly set.
2. For the demo executable project [UcglibSwiftIOTest](https://github.com/OmerFlame/UcglibSwiftIOTest), just as a reminder, the SPI mode and speed need to be set according to the datasheet, i.e. the SSD1351 needs both CPOL and CPHA to be `true` and speed is no more than 20MHz, but SPI 20MHz doesn't work since its actual speed will be a little higher than the set speed.
3. It seems that the font still has some problems, the two values below aren't printed correctly. After I change the font for hello world to the same font used for `Variable1` below, all texts are printed normally.